### PR TITLE
Proper escape handling in the parser

### DIFF
--- a/src/ion/section.rs
+++ b/src/ion/section.rs
@@ -385,7 +385,7 @@ mod tests {
             let first_row = section.rows.first().unwrap();
             assert_eq!(3, first_row.len());
             assert_eq!("", first_row[0].to_string());
-            assert_eq!("a|b", first_row[1].to_string());
+            assert_eq!("a\\|b", first_row[1].to_string());
             assert_eq!("a", first_row[2].to_string());
             assert_eq!(3, section.rows_without_header().len())
         }

--- a/src/ion/section.rs
+++ b/src/ion/section.rs
@@ -281,18 +281,20 @@ mod tests {
             let ion = ion!(
                 r#"
                 [FOO]
-                |head1 |head2 |head3 |
-                |------|------|------|
-                | a\|b | a\\b | a\nb |
+                |head1 |head2 |head3 |head4 | head5  |
+                |------|------|------|------|--------|
+                | a\|b | a\\b | a\nb | a\tb | a\\\nb |
                 "#
             );
 
             let section = ion.get("FOO").unwrap();
             let first_row = section.rows_without_header().first().unwrap();
-            assert_eq!(3, first_row.len());
+            assert_eq!(5, first_row.len());
             assert_eq!(Value::String("a|b".to_string()), first_row[0]);
             assert_eq!(Value::String("a\\b".to_string()), first_row[1]);
             assert_eq!(Value::String("a\nb".to_string()), first_row[2]);
+            assert_eq!(Value::String("a\tb".to_string()), first_row[3]);
+            assert_eq!(Value::String("a\\\nb".to_string()), first_row[4]);
             assert_eq!(1, section.rows_without_header().len())
         }
 

--- a/tests/data/test.ion
+++ b/tests/data/test.ion
@@ -3,6 +3,7 @@ ary = [ "a", "b", 3 ]
 first = "hello \\ hello \n hello \""
 # comment
 second ="another"
+third = "hello \\n world"
 bool = true
 
 [table]
@@ -13,7 +14,7 @@ bool = true
 # comment
 |  1| 2 |
 |  2| 3 |
-|  4 | one:"hello \" world" two:"world" |
+|  4 | one:"hello \" world" two:"hello \| world" three: "hello \\n world" |
 
 [mixed]
 a=1

--- a/tests/expected/test.ion
+++ b/tests/expected/test.ion
@@ -3,6 +3,7 @@ ary = [ "a", "b", 3 ]
 bool = true
 first = "hello \\ hello \n hello \""
 second = "another"
+third = "hello \\n world"
 
 [mixed]
 B = 2
@@ -16,5 +17,5 @@ a = 1
 | one | two |
 | 1 | 2 |
 | 2 | 3 |
-| 4 | one:"hello \" world" two:"world" |
+| 4 | one:"hello \" world" two:"hello \| world" three: "hello \\n world" |
 

--- a/tests/expected/test.ion
+++ b/tests/expected/test.ion
@@ -16,5 +16,5 @@ a = 1
 | one | two |
 | 1 | 2 |
 | 2 | 3 |
-| 4 | one:"hello \" world" two:"world" |
+| 4 | one:"hello " world" two:"world" |
 

--- a/tests/expected/test.ion
+++ b/tests/expected/test.ion
@@ -16,5 +16,5 @@ a = 1
 | one | two |
 | 1 | 2 |
 | 2 | 3 |
-| 4 | one:"hello " world" two:"world" |
+| 4 | one:"hello \" world" two:"world" |
 


### PR DESCRIPTION
The function `replace_escapes()` has been added, which iterates the input `&str` by char and replaces any valid escape sequences (`\n`, `\t`, `\\`, `\|`, `\"`).