### PR TITLE
release: dev into master for ion and ion-fmt 0.11.0

### DIFF
--- a/.github/workflows/crate-ci.yml
+++ b/.github/workflows/crate-ci.yml
@@ -1,0 +1,45 @@
+name: Crate CI Template
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: Workspace package name.
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Fmt (${{ inputs.package }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo fmt -p ${{ inputs.package }} -- --check
+
+  clippy:
+    name: Clippy (${{ inputs.package }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo clippy -p ${{ inputs.package }} --all-features --tests -- -D warnings
+
+  test_default:
+    name: Test Default (${{ inputs.package }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo test -p ${{ inputs.package }}
+
+  test_all_features:
+    name: Test All Features (${{ inputs.package }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo test -p ${{ inputs.package }} --all-features

--- a/.github/workflows/crate-ci.yml
+++ b/.github/workflows/crate-ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Fmt (${{ inputs.package }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo fmt -p ${{ inputs.package }} -- --check
 
@@ -24,7 +24,7 @@ jobs:
     name: Clippy (${{ inputs.package }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo clippy -p ${{ inputs.package }} --all-features --tests -- -D warnings
 
@@ -32,7 +32,7 @@ jobs:
     name: Test Default (${{ inputs.package }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test -p ${{ inputs.package }}
 
@@ -40,6 +40,6 @@ jobs:
     name: Test All Features (${{ inputs.package }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test -p ${{ inputs.package }} --all-features

--- a/.github/workflows/ion-fmt.yml
+++ b/.github/workflows/ion-fmt.yml
@@ -1,0 +1,29 @@
+name: ion-fmt CI
+
+on:
+  pull_request:
+    paths:
+      - "ion-fmt/**"
+      - "ion/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/crate-ci.yml"
+      - ".github/workflows/ion-fmt.yml"
+  push:
+    branches:
+      - dev
+      - master
+    paths:
+      - "ion-fmt/**"
+      - "ion/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/crate-ci.yml"
+      - ".github/workflows/ion-fmt.yml"
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/crate-ci.yml
+    with:
+      package: ion-fmt

--- a/.github/workflows/ion.yml
+++ b/.github/workflows/ion.yml
@@ -1,0 +1,27 @@
+name: ion CI
+
+on:
+  pull_request:
+    paths:
+      - "ion/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/crate-ci.yml"
+      - ".github/workflows/ion.yml"
+  push:
+    branches:
+      - dev
+      - master
+    paths:
+      - "ion/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/crate-ci.yml"
+      - ".github/workflows/ion.yml"
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/crate-ci.yml
+    with:
+      package: ion

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -14,7 +14,7 @@ jobs:
     name: Fmt (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo fmt --all -- --check
 
@@ -22,7 +22,7 @@ jobs:
     name: Clippy (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo clippy --workspace --all-features --tests -- -D warnings
 
@@ -30,7 +30,7 @@ jobs:
     name: Test Default (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --workspace
 
@@ -38,7 +38,7 @@ jobs:
     name: Test All Features (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --workspace --all-features
 
@@ -46,7 +46,7 @@ jobs:
     name: Audit (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo install cargo-audit --locked
       - run: cargo audit

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,45 +1,49 @@
-name: Test
-on: [ push, pull_request ]
+name: workspace CI
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   fmt:
-    name: Fmt (${{ matrix.package }})
+    name: Fmt (workspace)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [ion, ion-fmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo fmt -p ${{ matrix.package }} -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
-    name: Clippy (${{ matrix.package }})
+    name: Clippy (workspace)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [ion, ion-fmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo clippy -p ${{ matrix.package }} --all-features --tests -- -D warnings
+      - run: cargo clippy --workspace --all-features --tests -- -D warnings
 
-  test:
-    name: Test (${{ matrix.package }})
+  test_default:
+    name: Test Default (workspace)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [ion, ion-fmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo test -p ${{ matrix.package }} --all-features
+      - run: cargo test --workspace
+
+  test_all_features:
+    name: Test All Features (workspace)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo test --workspace --all-features
 
   audit:
-    name: Audit
+    name: Audit (workspace)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- Reduce string value allocation overhead by storing `Value::String` as `Box<str>`
+
+### Breaking changes
+
+- `Value::as_string()` now returns `Option<&str>` instead of `Option<&String>`
+
 ## 0.10.0
 
 ### Added
@@ -31,7 +39,6 @@
 ### Breaking changes
 
 - Repository layout changed for contributors: the crate manifest moved from `./Cargo.toml` to `./ion/Cargo.toml`
-- Public library API remains unchanged
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Reduce string value allocation overhead by storing `Value::String` as `Box<str>`
 - Make `ion-fmt --help` report active dictionary build mode (`BTreeMap` sorted keys vs `dictionary-indexmap` insertion order)
+- Split CI into crate-specific workflows (`ion.yml`, `ion-fmt.yml`) and add a full workspace safety workflow (`workspace.yml`) for `master`
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Reduce string value allocation overhead by storing `Value::String` as `Box<str>`
+- Make `ion-fmt --help` report active dictionary build mode (`BTreeMap` sorted keys vs `dictionary-indexmap` insertion order)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.11.0
+
 ### Changed
 
 - Reduce string value allocation overhead by storing `Value::String` as `Box<str>`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["ion", "ion-fmt"]
 resolver = "2"
 
 [workspace.dependencies]
-ion = { version = "0.10.0", path = "ion" }
+ion = { version = "0.11.0", path = "ion" }
 
 # crates.io
 clap = { version = "4.6", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Default dictionary backend (`BTreeMap`):
 
 ```toml
 [dependencies]
-ion = "0.10.0"
+ion = "0.11.0"
 ```
 
 Insertion-ordered dictionaries with `IndexMap`:
 
 ```toml
 [dependencies]
-ion = { version = "0.10.0", features = ["dictionary-indexmap"] }
+ion = { version = "0.11.0", features = ["dictionary-indexmap"] }
 ```
 
 ## Related Crates

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ion &emsp; [![crates-badge]][crates-link] [![docs-badge]][docs-link]
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
-[![Test Status](https://github.com/ion-rs/ion/workflows/Test/badge.svg)](https://github.com/ion-rs/ion/actions)
+[![ion CI](https://github.com/ion-rs/ion/actions/workflows/ion.yml/badge.svg?branch=master)](https://github.com/ion-rs/ion/actions/workflows/ion.yml)
+[![ion-fmt CI](https://github.com/ion-rs/ion/actions/workflows/ion-fmt.yml/badge.svg?branch=master)](https://github.com/ion-rs/ion/actions/workflows/ion-fmt.yml)
+[![workspace CI](https://github.com/ion-rs/ion/actions/workflows/workspace.yml/badge.svg?branch=master)](https://github.com/ion-rs/ion/actions/workflows/workspace.yml)
 
 [crates-badge]: https://img.shields.io/crates/v/ion.svg
 [crates-link]: https://crates.io/crates/ion

--- a/ion-fmt/Cargo.toml
+++ b/ion-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion-fmt"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/ion-rs/ion"

--- a/ion-fmt/Cargo.toml
+++ b/ion-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion-fmt"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/ion-rs/ion"

--- a/ion-fmt/README.indexmap.md
+++ b/ion-fmt/README.indexmap.md
@@ -28,6 +28,8 @@ let formatted = format_str(raw).unwrap();
 $ ion-fmt --help
 Formats Ion files.
 
+Build mode: dictionary-indexmap (dictionary keys preserve insertion order).
+
 Usage: ion-fmt [COMMAND]
 
 Commands:
@@ -37,8 +39,11 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```
 

--- a/ion-fmt/README.indexmap.md
+++ b/ion-fmt/README.indexmap.md
@@ -29,10 +29,10 @@ Options:
 
 ```console
 $ ion-fmt --version
-ion-fmt 0.10.1
+ion-fmt 0.11.0
 
 $ ion-fmt -V
-ion-fmt 0.10.1
+ion-fmt 0.11.0
 
 ```
 

--- a/ion-fmt/README.indexmap.md
+++ b/ion-fmt/README.indexmap.md
@@ -1,26 +1,6 @@
 # ion-fmt
 
-`ion-fmt` formats Ion documents from Rust code and from the terminal.
-
-## Feature Flags
-
-- Active mode in this file: `dictionary-indexmap` (insertion-order dictionaries).
-- Default mode (`BTreeMap`, sorted keys) is documented in `README.md`.
-
 This file is used by `trycmd` when tests run with `--features dictionary-indexmap`.
-
-## Library
-
-```rust
-use ion_fmt::format_str;
-
-let raw = r#"
-    [A]
-    [B]
-"#;
-
-let formatted = format_str(raw).unwrap();
-```
 
 ## CLI
 
@@ -49,52 +29,10 @@ Options:
 
 ```console
 $ ion-fmt --version
-ion-fmt 0.10.0
+ion-fmt 0.10.1
 
 $ ion-fmt -V
-ion-fmt 0.10.0
-
-```
-
-```console
-$ ion-fmt format --help
-Format files in place or stdin
-
-Usage: ion-fmt format [PATH]...
-
-Arguments:
-  [PATH]...  Ion file paths. Reads stdin when omitted
-
-Options:
-  -h, --help  Print help
-
-```
-
-```console
-$ ion-fmt check --help
-Check formatting without writing changes
-
-Usage: ion-fmt check [PATH]...
-
-Arguments:
-  [PATH]...  Ion file paths. Reads stdin when omitted
-
-Options:
-  -h, --help  Print help
-
-```
-
-```console
-$ ion-fmt stdout --help
-Print formatted output to stdout
-
-Usage: ion-fmt stdout [PATH]...
-
-Arguments:
-  [PATH]...  Ion file paths. Reads stdin when omitted
-
-Options:
-  -h, --help  Print help
+ion-fmt 0.10.1
 
 ```
 

--- a/ion-fmt/README.md
+++ b/ion-fmt/README.md
@@ -1,4 +1,10 @@
-# ion-fmt
+# ion-fmt &emsp; [![crates-badge]][crates-link]
+
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
+[![ion-fmt CI](https://github.com/ion-rs/ion/actions/workflows/ion-fmt.yml/badge.svg?branch=master)](https://github.com/ion-rs/ion/actions/workflows/ion-fmt.yml)
+
+[crates-badge]: https://img.shields.io/crates/v/ion.svg
+[crates-link]: https://crates.io/crates/ion-fmt
 
 `ion-fmt` formats Ion documents from Rust code and from the terminal.
 
@@ -9,6 +15,15 @@
 
 Default examples in this file are validated by `trycmd`.
 For `dictionary-indexmap` snapshots, see `README.indexmap.md`.
+
+## Install
+
+- Default backend (`BTreeMap`, sorted dictionary keys): `cargo install ion-fmt`
+- `dictionary-indexmap` backend (insertion-order dictionary keys): `cargo install ion-fmt --features dictionary-indexmap`
+- From a local checkout (default backend): `cargo install --path ion-fmt`
+- From a local checkout (`dictionary-indexmap`): `cargo install --path ion-fmt --features dictionary-indexmap`
+
+`ion-fmt` backend is selected at build/install time; one installed binary uses one backend.
 
 ## Library
 
@@ -50,52 +65,10 @@ Options:
 
 ```console
 $ ion-fmt --version
-ion-fmt 0.10.0
+ion-fmt 0.10.1
 
 $ ion-fmt -V
-ion-fmt 0.10.0
-
-```
-
-```console
-$ ion-fmt format --help
-Format files in place or stdin
-
-Usage: ion-fmt format [PATH]...
-
-Arguments:
-  [PATH]...  Ion file paths. Reads stdin when omitted
-
-Options:
-  -h, --help  Print help
-
-```
-
-```console
-$ ion-fmt check --help
-Check formatting without writing changes
-
-Usage: ion-fmt check [PATH]...
-
-Arguments:
-  [PATH]...  Ion file paths. Reads stdin when omitted
-
-Options:
-  -h, --help  Print help
-
-```
-
-```console
-$ ion-fmt stdout --help
-Print formatted output to stdout
-
-Usage: ion-fmt stdout [PATH]...
-
-Arguments:
-  [PATH]...  Ion file paths. Reads stdin when omitted
-
-Options:
-  -h, --help  Print help
+ion-fmt 0.10.1
 
 ```
 

--- a/ion-fmt/README.md
+++ b/ion-fmt/README.md
@@ -65,10 +65,10 @@ Options:
 
 ```console
 $ ion-fmt --version
-ion-fmt 0.10.1
+ion-fmt 0.11.0
 
 $ ion-fmt -V
-ion-fmt 0.10.1
+ion-fmt 0.11.0
 
 ```
 

--- a/ion-fmt/README.md
+++ b/ion-fmt/README.md
@@ -127,3 +127,7 @@ title = "rate-plan"
 
 The CLI arguments are implemented with `clap` derive and subcommands.
 When no subcommand is provided, `ion-fmt` defaults to the `stdout` command (stdin -> stdout).
+
+## Related Crates
+
+- [`ion`](https://crates.io/crates/ion): library for Ion documents.

--- a/ion-fmt/README.md
+++ b/ion-fmt/README.md
@@ -29,6 +29,8 @@ let formatted = format_str(raw).unwrap();
 $ ion-fmt --help
 Formats Ion files.
 
+Build mode: default dictionary backend (BTreeMap, dictionary keys are sorted).
+
 Usage: ion-fmt [COMMAND]
 
 Commands:
@@ -38,8 +40,11 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```
 

--- a/ion-fmt/src/display.rs
+++ b/ion-fmt/src/display.rs
@@ -315,7 +315,7 @@ mod tests {
     }
 
     fn string(value: &str) -> Value {
-        Value::String(value.to_owned())
+        Value::String(value.into())
     }
 
     static ION_FORMAT_CASE: LazyLock<IonFormatTestCase> = LazyLock::new(|| IonFormatTestCase {

--- a/ion-fmt/src/main.rs
+++ b/ion-fmt/src/main.rs
@@ -11,6 +11,16 @@ use ion_fmt::{format_file, format_str, write_formatted_file};
 use std::io::{self, Read};
 use std::path::PathBuf;
 
+#[cfg(feature = "dictionary-indexmap")]
+const CLI_ABOUT: &str = "Formats Ion files.";
+#[cfg(feature = "dictionary-indexmap")]
+const CLI_LONG_ABOUT: &str = "Formats Ion files.\n\nBuild mode: dictionary-indexmap (dictionary keys preserve insertion order).";
+
+#[cfg(not(feature = "dictionary-indexmap"))]
+const CLI_ABOUT: &str = "Formats Ion files.";
+#[cfg(not(feature = "dictionary-indexmap"))]
+const CLI_LONG_ABOUT: &str = "Formats Ion files.\n\nBuild mode: default dictionary backend (BTreeMap, dictionary keys are sorted).";
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Mode {
     FormatInPlace,
@@ -19,7 +29,7 @@ enum Mode {
 }
 
 #[derive(Debug, Parser)]
-#[command(name = "ion-fmt", version, about = "Formats Ion files.")]
+#[command(name = "ion-fmt", version, about = CLI_ABOUT, long_about = CLI_LONG_ABOUT)]
 struct Cli {
     #[command(subcommand)]
     command: Option<CliCommand>,

--- a/ion/Cargo.toml
+++ b/ion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion"
-version = "0.10.0"
+version = "0.11.0"
 description = "*.ion file parser"
 edition = "2024"
 license = "MIT"

--- a/ion/README.md
+++ b/ion/README.md
@@ -23,14 +23,14 @@ Default dictionary backend (`BTreeMap`):
 
 ```toml
 [dependencies]
-ion = "0.10.0"
+ion = "0.11.0"
 ```
 
 Insertion-ordered dictionaries with `IndexMap`:
 
 ```toml
 [dependencies]
-ion = { version = "0.10.0", features = ["dictionary-indexmap"] }
+ion = { version = "0.11.0", features = ["dictionary-indexmap"] }
 ```
 
 ## Rust Quick Start

--- a/ion/README.md
+++ b/ion/README.md
@@ -1,7 +1,7 @@
 # ion &emsp; [![crates-badge]][crates-link] [![docs-badge]][docs-link]
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
-[![Test Status](https://github.com/ion-rs/ion/workflows/Test/badge.svg)](https://github.com/ion-rs/ion/actions)
+[![ion CI](https://github.com/ion-rs/ion/actions/workflows/ion.yml/badge.svg?branch=master)](https://github.com/ion-rs/ion/actions/workflows/ion.yml)
 
 [crates-badge]: https://img.shields.io/crates/v/ion.svg
 [crates-link]: https://crates.io/crates/ion

--- a/ion/src/ion.rs
+++ b/ion/src/ion.rs
@@ -193,10 +193,7 @@ mod tests {
     #[test_case(&*BOOLEAN_VALUE_CASE; "boolean")]
     #[test_case(&*INTEGER_VALUE_CASE; "integer")]
     fn value_accessors(case: &ValueConversionTestCase) {
-        assert_eq!(
-            case.expected_string.map(str::to_owned).as_ref(),
-            case.value.as_string()
-        );
+        assert_eq!(case.expected_string, case.value.as_string());
         assert_eq!(case.expected_boolean, case.value.as_boolean());
         assert_eq!(case.expected_integer, case.value.as_integer());
         assert_eq!(case.expected_str, case.value.as_str());

--- a/ion/src/ion/display.rs
+++ b/ion/src/ion/display.rs
@@ -142,7 +142,7 @@ mod tests {
     }
 
     fn string(value: &str) -> Value {
-        Value::String(value.to_owned())
+        Value::String(value.into())
     }
 
     fn section(entries: Vec<(&str, Value)>, rows: Vec<Vec<Value>>) -> Section {

--- a/ion/src/ion/from_ion.rs
+++ b/ion/src/ion/from_ion.rs
@@ -114,7 +114,7 @@ mod tests {
     }
 
     static STRING_CASE: LazyLock<StringTestCase> = LazyLock::new(|| StringTestCase {
-        value: Value::String("foo".to_owned()),
+        value: Value::String("foo".into()),
         expected: "foo",
     });
 

--- a/ion/src/ion/from_row.rs
+++ b/ion/src/ion/from_row.rs
@@ -86,7 +86,7 @@ mod tests {
     static FROM_ROW_CASE: LazyLock<TestCase> = LazyLock::new(|| TestCase {
         row: "1|foo"
             .split('|')
-            .map(|s| Value::String(s.to_owned()))
+            .map(|s| Value::String(s.into()))
             .collect(),
         expected: Foo {
             foo: 1,
@@ -102,7 +102,7 @@ mod tests {
     static PARSE_ROW_CASE: LazyLock<TestCase> = LazyLock::new(|| TestCase {
         row: "2|bar"
             .split('|')
-            .map(|s| Value::String(s.to_owned()))
+            .map(|s| Value::String(s.into()))
             .collect(),
         expected: Foo {
             foo: 2,
@@ -116,7 +116,7 @@ mod tests {
     }
 
     static FROM_ROW_ERROR_CASE: LazyLock<ErrorTestCase> = LazyLock::new(|| ErrorTestCase {
-        row: vec![Value::String("oops".to_owned())],
+        row: vec![Value::String("oops".into())],
         expected_error: "foo",
     });
     #[test_case(&*FROM_ROW_ERROR_CASE; "from row error")]

--- a/ion/src/ion/section.rs
+++ b/ion/src/ion/section.rs
@@ -358,11 +358,11 @@ mod tests {
                 | a\|b | a\\b | a\nb | a\tb | a\\\nb |
             ",
             expected_first_row: vec![
-                Value::String("a|b".to_owned()),
-                Value::String("a\\b".to_owned()),
-                Value::String("a\nb".to_owned()),
-                Value::String("a\tb".to_owned()),
-                Value::String("a\\\nb".to_owned()),
+                Value::String("a|b".into()),
+                Value::String("a\\b".into()),
+                Value::String("a\nb".into()),
+                Value::String("a\tb".into()),
+                Value::String("a\\\nb".into()),
             ],
             expected_rows: 1,
             use_rows_without_header: true,
@@ -376,9 +376,9 @@ mod tests {
                 |     | b     |     |
             ",
             expected_first_row: vec![
-                Value::String(String::new()),
-                Value::String("a|b".to_owned()),
-                Value::String("a".to_owned()),
+                Value::String(String::new().into()),
+                Value::String("a|b".into()),
+                Value::String("a".into()),
             ],
             expected_rows: 3,
             use_rows_without_header: false,
@@ -456,7 +456,7 @@ mod tests {
             .insert("name".to_owned(), Value::new_string("foo"));
 
         match section.get_mut("name") {
-            Some(Value::String(value)) => *value = "bar".to_owned(),
+            Some(Value::String(value)) => *value = "bar".into(),
             other => panic!("unexpected mutable value: {other:?}"),
         }
 

--- a/ion/src/ion/value.rs
+++ b/ion/src/ion/value.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
-    String(String),
+    String(Box<str>),
     Integer(i64),
     Float(f64),
     Boolean(bool),
@@ -14,7 +14,7 @@ pub enum Value {
 impl Value {
     #[must_use]
     pub fn new_string(value: &str) -> Self {
-        Value::String(value.to_owned())
+        Value::String(value.into())
     }
 
     #[must_use]
@@ -40,7 +40,7 @@ impl Value {
     }
 
     #[must_use]
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Value::String(v) => Some(v),
             _ => None,
@@ -54,10 +54,7 @@ impl Value {
 
     #[must_use]
     pub fn as_str(&self) -> Option<&str> {
-        match self {
-            Value::String(v) => Some(v.as_str()),
-            _ => None,
-        }
+        self.as_string()
     }
 
     #[must_use]
@@ -136,7 +133,7 @@ impl FromStr for Value {
     type Err = IonError;
 
     fn from_str(s: &str) -> Result<Value, IonError> {
-        Ok(Value::String(s.to_owned()))
+        Ok(Value::String(s.into()))
     }
 }
 

--- a/ion/src/parser.rs
+++ b/ion/src/parser.rs
@@ -322,7 +322,7 @@ impl<'a> Parser<'a> {
         self.cur.next();
 
         self.slice_to_excluding('"')
-            .map(|s| Value::String(replace_escapes(s, true)))
+            .map(|s| Value::String(replace_escapes(s, true).into()))
     }
 
     fn keyval_sep(&mut self) -> bool {
@@ -360,7 +360,7 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            row.push(Value::String(self.cell()));
+            row.push(Value::String(self.cell().into()));
         }
 
         Element::Row(row)
@@ -784,7 +784,7 @@ mod tests {
     }
 
     fn string(value: &str) -> Value {
-        Value::String(value.to_owned())
+        Value::String(value.into())
     }
 
     fn array(values: Vec<Value>) -> Value {
@@ -844,7 +844,7 @@ mod tests {
     fn finish_string(case: &FinishStringTestCase) {
         let mut parser = Parser::new(case.raw);
         let actual = parser.finish_string().map(|value| match value {
-            Value::String(value) => value,
+            Value::String(value) => value.to_string(),
             other => panic!("expected string value, got {other:?}"),
         });
         assert_eq!(case.expected.map(str::to_owned), actual);


### PR DESCRIPTION
## Summary

Merge `dev` into `master` to ship the `0.11.0` release for both crates:
- `ion`
- `ion-fmt`

## What’s included

- Update README dependency examples to `ion = "0.11.0"`
- Update `ion-fmt` README CLI snapshots to `ion-fmt 0.11.0`
- Keep release docs aligned across workspace and crate READMEs
- Include recent CI/workflow split improvements and help-text updates already in `dev`

## Breaking changes

- `Value::as_string()` now returns `Option<&str>` instead of `Option<&String>`