### PR TITLE
feat(ion-fmt): switch to options-first formatting API and add --style

### DIFF
--- a/ion-fmt/CHANGELOG.md
+++ b/ion-fmt/CHANGELOG.md
@@ -5,6 +5,30 @@ Repository and workspace maintenance changes are intentionally omitted.
 
 ## Unreleased
 
+No changes yet.
+
+## 0.13.0
+
+### Added
+
+- Add `--style dictionary-field=singleline|multiline` CLI option
+- Add formatter options API (`FormatOptions`) with dictionary field style control
+- Add public `DictionaryDisplay` and `DictionaryFieldDisplay` adapters
+
+### Changed
+
+- Make multiline the default dictionary-field rendering behavior
+
+### Breaking changes
+
+- Remove wrapper APIs in favor of options-explicit variants:
+  `format_str` -> `format_str_with_options`,
+  `check_str` -> `check_str_with_options`,
+  `format_file` -> `format_file_with_options`,
+  `write_formatted_file` -> `write_formatted_file_with_options`,
+  `display` -> `display_with_options`,
+  `format_ion` -> `format_ion_with_options`
+
 ## 0.12.0
 
 ### Changed

--- a/ion-fmt/Cargo.toml
+++ b/ion-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion-fmt"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/ion-rs/ion"

--- a/ion-fmt/README.indexmap.md
+++ b/ion-fmt/README.indexmap.md
@@ -10,7 +10,7 @@ Formats Ion files.
 
 Build mode: dictionary-indexmap (section names and dictionary keys preserve insertion order).
 
-Usage: ion-fmt [COMMAND]
+Usage: ion-fmt [OPTIONS] [COMMAND]
 
 Commands:
   format  Format files in place or stdin
@@ -19,6 +19,11 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
+      --style <KEY=VALUE>
+          Style options in `key=value` form (repeatable).
+          
+          Supported: - `dictionary-field=multiline` (default) - `dictionary-field=singleline`
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -29,10 +34,10 @@ Options:
 
 ```console
 $ ion-fmt --version
-ion-fmt 0.12.0
+ion-fmt 0.13.0
 
 $ ion-fmt -V
-ion-fmt 0.12.0
+ion-fmt 0.13.0
 
 ```
 

--- a/ion-fmt/README.md
+++ b/ion-fmt/README.md
@@ -28,15 +28,26 @@ For `dictionary-indexmap` snapshots, see `README.indexmap.md`.
 ## Library
 
 ```rust
-use ion_fmt::format_str;
+use ion_fmt::{FormatOptions, format_str_with_options};
 
 let raw = r#"
     [A]
     [B]
 "#;
 
-let formatted = format_str(raw).unwrap();
+let formatted = format_str_with_options(raw, FormatOptions::default()).unwrap();
 ```
+
+Options-first API:
+
+- `format_str_with_options`
+- `check_str_with_options`
+- `format_file_with_options`
+- `write_formatted_file_with_options`
+- `display_with_options`
+- `format_ion_with_options`
+- `DictionaryDisplay`
+- `DictionaryFieldDisplay`
 
 ## CLI
 
@@ -46,7 +57,7 @@ Formats Ion files.
 
 Build mode: default dictionary backend (BTreeMap, section names and dictionary keys are sorted).
 
-Usage: ion-fmt [COMMAND]
+Usage: ion-fmt [OPTIONS] [COMMAND]
 
 Commands:
   format  Format files in place or stdin
@@ -55,6 +66,11 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
+      --style <KEY=VALUE>
+          Style options in `key=value` form (repeatable).
+          
+          Supported: - `dictionary-field=multiline` (default) - `dictionary-field=singleline`
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -65,10 +81,10 @@ Options:
 
 ```console
 $ ion-fmt --version
-ion-fmt 0.12.0
+ion-fmt 0.13.0
 
 $ ion-fmt -V
-ion-fmt 0.12.0
+ion-fmt 0.13.0
 
 ```
 

--- a/ion-fmt/src/display.rs
+++ b/ion-fmt/src/display.rs
@@ -4,8 +4,47 @@
 //! values and delegates parsing and validation to the `ion` crate.
 
 use crate::columns_width::{Column, ColumnsWidth};
-use ion::{Ion, Row, Section, Value};
-use std::fmt;
+use ion::{Dictionary, Ion, Row, Section, Value};
+use std::fmt::{self, Write};
+use std::str::FromStr;
+
+/// Formatting options used when rendering Ion documents.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct FormatOptions {
+    /// Dictionary rendering options.
+    pub dictionary: DictionaryOptions,
+}
+
+/// Options that control dictionary formatting behavior.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DictionaryOptions {
+    /// Style used for dictionary fields.
+    pub field: FieldStyle,
+}
+
+/// Formatting style for dictionary string fields.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FieldStyle {
+    /// Render dictionary strings as escaped single-line values.
+    Singleline,
+    /// Preserve embedded newline characters as multiline quoted values.
+    #[default]
+    Multiline,
+}
+
+impl FromStr for FieldStyle {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "singleline" => Ok(Self::Singleline),
+            "multiline" => Ok(Self::Multiline),
+            _ => Err(format!(
+                "Unsupported `dictionary-field` style `{value}`. Expected `singleline` or `multiline`."
+            )),
+        }
+    }
+}
 
 /// Display adapter that renders an [`Ion`] document with canonical formatting.
 ///
@@ -14,13 +53,48 @@ use std::fmt;
 #[derive(Clone, Debug)]
 pub struct IonDisplay<'a> {
     ion: &'a Ion,
+    options: FormatOptions,
 }
 
 impl<'a> IonDisplay<'a> {
-    /// Creates a display adapter for an Ion document.
+    /// Creates a display adapter with explicit formatting options.
     #[must_use]
-    pub fn new(ion: &'a Ion) -> Self {
-        Self { ion }
+    pub fn new(ion: &'a Ion, options: FormatOptions) -> Self {
+        Self { ion, options }
+    }
+}
+
+/// Display adapter that renders dictionary fields from a section.
+///
+/// This is useful when callers want to format only dictionary values instead
+/// of a full section or full document.
+#[derive(Clone, Debug)]
+pub struct DictionaryDisplay<'a> {
+    dictionary: &'a Dictionary,
+    field: FieldStyle,
+}
+
+impl<'a> DictionaryDisplay<'a> {
+    /// Creates a dictionary display adapter with explicit dictionary field style.
+    #[must_use]
+    pub fn new(dictionary: &'a Dictionary, field: FieldStyle) -> Self {
+        Self { dictionary, field }
+    }
+}
+
+/// Display adapter that renders a single dictionary key-value pair.
+#[derive(Clone, Debug)]
+pub struct DictionaryFieldDisplay<'a> {
+    key: &'a str,
+    value: &'a Value,
+    field: FieldStyle,
+}
+
+impl<'a> DictionaryFieldDisplay<'a> {
+    /// Creates a dictionary field display adapter with explicit dictionary field style.
+    #[must_use]
+    pub fn new(key: &'a str, value: &'a Value, field: FieldStyle) -> Self {
+        Self { key, value, field }
     }
 }
 
@@ -29,6 +103,7 @@ struct SectionDisplay<'a> {
     columns_width: ColumnsWidth,
     name: &'a str,
     section: &'a Section,
+    options: FormatOptions,
 }
 
 #[derive(Clone, Debug)]
@@ -52,7 +127,7 @@ pub(crate) enum RowTypeDisplay {
 }
 
 impl<'a> SectionDisplay<'a> {
-    fn new(name: &'a str, section: &'a Section) -> Self {
+    fn new(name: &'a str, section: &'a Section, options: FormatOptions) -> Self {
         let columns_width = section
             .rows
             .iter()
@@ -62,32 +137,28 @@ impl<'a> SectionDisplay<'a> {
             columns_width,
             name,
             section,
+            options,
         }
     }
 }
 
-/// Returns a display adapter that can be rendered with `to_string()`.
-///
-/// This avoids allocating the final string until the formatter output is
-/// actually rendered.
+/// Returns a display adapter rendered with explicit formatting options.
 #[must_use]
-pub fn display(ion: &Ion) -> IonDisplay<'_> {
-    IonDisplay::new(ion)
+pub fn display_with_options(ion: &Ion, options: FormatOptions) -> IonDisplay<'_> {
+    IonDisplay::new(ion, options)
 }
 
-/// Formats an Ion document into its canonical string representation.
-///
-/// This is equivalent to `display(ion).to_string()`.
+/// Formats an Ion document using explicit formatting options.
 #[must_use]
-pub fn format_ion(ion: &Ion) -> String {
-    display(ion).to_string()
+pub fn format_ion_with_options(ion: &Ion, options: FormatOptions) -> String {
+    display_with_options(ion, options).to_string()
 }
 
 impl fmt::Display for IonDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.ion
             .iter()
-            .map(|(name, section)| SectionDisplay::new(name, section))
+            .map(|(name, section)| SectionDisplay::new(name, section, self.options))
             .try_for_each(|section| writeln!(f, "{section}"))
     }
 }
@@ -95,7 +166,7 @@ impl fmt::Display for IonDisplay<'_> {
 impl fmt::Display for SectionDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "[{}]", self.name)?;
-        dictionary(f, self.section.dictionary.iter())?;
+        DictionaryDisplay::new(&self.section.dictionary, self.options.dictionary.field).fmt(f)?;
 
         if self.section.rows.is_empty() {
             return Ok(());
@@ -106,6 +177,26 @@ impl fmt::Display for SectionDisplay<'_> {
             rows: &self.section.rows,
         }
         .fmt(f)
+    }
+}
+
+impl fmt::Display for DictionaryDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.dictionary
+            .iter()
+            .try_for_each(|(key, value)| DictionaryFieldDisplay::new(key, value, self.field).fmt(f))
+    }
+}
+
+impl fmt::Display for DictionaryFieldDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value {
+            Value::String(text) if self.field == FieldStyle::Multiline && text.contains('\n') => {
+                write_dictionary_multiline_string(f, self.key, text)
+            }
+            Value::String(_) => writeln!(f, "{} = \"{}\"", self.key, self.value),
+            _ => writeln!(f, "{} = {}", self.key, self.value),
+        }
     }
 }
 
@@ -152,17 +243,20 @@ impl fmt::Display for RowDisplay<'_> {
     }
 }
 
-fn dictionary<'a>(
+fn write_dictionary_multiline_string(
     f: &mut fmt::Formatter<'_>,
-    mut fields: impl Iterator<Item = (&'a String, &'a Value)>,
+    key: &str,
+    text: &str,
 ) -> fmt::Result {
-    fields.try_for_each(|(key, value)| {
-        if value.is_string() {
-            writeln!(f, "{key} = \"{value}\"")
-        } else {
-            writeln!(f, "{key} = {value}")
+    write!(f, "{key} = \"")?;
+    for ch in text.chars() {
+        match ch {
+            '\\' => f.write_str("\\\\")?,
+            '"' => f.write_str("\\\"")?,
+            _ => f.write_char(ch)?,
         }
-    })
+    }
+    writeln!(f, "\"")
 }
 
 fn header(f: &mut fmt::Formatter<'_>, columns: &RowDisplay<'_>) -> fmt::Result {
@@ -298,6 +392,7 @@ mod tests {
     use super::*;
     use crate::columns_width::{Column, ColumnType};
     use indoc::indoc;
+    use ion::Dictionary;
     use pretty_assertions::assert_eq;
     use std::sync::LazyLock;
     use test_case::test_case;
@@ -305,6 +400,7 @@ mod tests {
     #[derive(Debug)]
     struct IonFormatTestCase {
         raw: &'static str,
+        options: FormatOptions,
         expected: &'static str,
     }
 
@@ -312,6 +408,28 @@ mod tests {
     struct DataOrSeparatorTestCase {
         row: Row,
         expected: RowTypeDisplay,
+    }
+
+    #[derive(Debug)]
+    struct DictionaryDisplayTestCase {
+        dictionary: Dictionary,
+        field: FieldStyle,
+        expected: &'static str,
+    }
+
+    #[derive(Debug)]
+    struct DictionaryFieldDisplayTestCase {
+        key: &'static str,
+        value: Value,
+        field: FieldStyle,
+        expected: &'static str,
+    }
+
+    #[derive(Debug)]
+    struct WriteDictionaryMultilineStringTestCase {
+        key: &'static str,
+        text: &'static str,
+        expected: &'static str,
     }
 
     #[derive(Debug)]
@@ -326,6 +444,14 @@ mod tests {
         Value::String(value.into())
     }
 
+    fn dictionary(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Dictionary {
+        let mut dictionary = Dictionary::new();
+        for (key, value) in entries {
+            dictionary.insert(key.to_owned(), value);
+        }
+        dictionary
+    }
+
     static ION_FORMAT_CASE: LazyLock<IonFormatTestCase> = LazyLock::new(|| IonFormatTestCase {
         raw: indoc! {r#"
             [ALPHA]
@@ -337,6 +463,11 @@ mod tests {
             | 1   | A    |
             | 22  | B    |
         "#},
+        options: FormatOptions {
+            dictionary: DictionaryOptions {
+                field: FieldStyle::Singleline,
+            },
+        },
         expected: indoc! {r#"
             [ALPHA]
             name = "foo"
@@ -355,19 +486,278 @@ mod tests {
                 [ALPHA]
                 value = 7
             "},
+            options: FormatOptions {
+                dictionary: DictionaryOptions {
+                    field: FieldStyle::Singleline,
+                },
+            },
             expected: indoc! {r"
                 [ALPHA]
                 value = 7
 
             "},
         });
+    static ION_FORMAT_MULTILINE_DICTIONARY_STRING_CASE: LazyLock<IonFormatTestCase> = LazyLock::new(
+        || IonFormatTestCase {
+            raw: indoc! {r#"
+                [Data]
+                select = "
+                    SELECT column
+                    FROM table t1
+                    INNER JOIN t2
+                        ON t1.id = t2.
+                    WHERE t1.userid = {{ user_id }}
+                    ORDER BY name ASC
+                "
+
+                [Table]
+                |   col1   |
+                |--------|
+                | name1 |
+                | name2 |
+            "#},
+            options: FormatOptions {
+                dictionary: DictionaryOptions {
+                    field: FieldStyle::Singleline,
+                },
+            },
+            expected: indoc! {r#"
+                [Data]
+                select = "\n    SELECT column\n    FROM table t1\n    INNER JOIN t2\n        ON t1.id = t2.\n    WHERE t1.userid = {{ user_id }}\n    ORDER BY name ASC\n"
+
+                [Table]
+                |  col1 |
+                |-------|
+                | name1 |
+                | name2 |
+
+            "#},
+        },
+    );
+    const ION_FORMAT_MULTILINE_DICTIONARY_STRING_WITH_MULTILINE_STYLE_CASE: IonFormatTestCase =
+        IonFormatTestCase {
+            raw: indoc! {r#"
+            [Data]
+            select = "
+                SELECT column
+                FROM table t1
+                INNER JOIN t2
+                    ON t1.id = t2.
+                WHERE t1.userid = {{ user_id }}
+                ORDER BY name ASC
+            "
+
+            [Table]
+            |   col1   |
+            |--------|
+            | name1 |
+            | name2 |
+        "#},
+            options: FormatOptions {
+                dictionary: DictionaryOptions {
+                    field: FieldStyle::Multiline,
+                },
+            },
+            expected: indoc! {r#"
+            [Data]
+            select = "
+                SELECT column
+                FROM table t1
+                INNER JOIN t2
+                    ON t1.id = t2.
+                WHERE t1.userid = {{ user_id }}
+                ORDER BY name ASC
+            "
+
+            [Table]
+            |  col1 |
+            |-------|
+            | name1 |
+            | name2 |
+
+        "#},
+        };
+    const ION_FORMAT_MULTILINE_DICTIONARY_STRING_WITH_SINGLELINE_STYLE_CASE: IonFormatTestCase =
+        IonFormatTestCase {
+            options: FormatOptions {
+                dictionary: DictionaryOptions {
+                    field: FieldStyle::Singleline,
+                },
+            },
+            expected: indoc! {r#"
+            [Data]
+            select = "\n    SELECT column\n    FROM table t1\n    INNER JOIN t2\n        ON t1.id = t2.\n    WHERE t1.userid = {{ user_id }}\n    ORDER BY name ASC\n"
+
+            [Table]
+            |  col1 |
+            |-------|
+            | name1 |
+            | name2 |
+
+        "#},
+            ..ION_FORMAT_MULTILINE_DICTIONARY_STRING_WITH_MULTILINE_STYLE_CASE
+        };
 
     #[test_case(&*ION_FORMAT_CASE; "formats ion document")]
     #[test_case(&*ION_FORMAT_NON_STRING_DICTIONARY_CASE; "formats non string dictionary value")]
+    #[test_case(
+        &*ION_FORMAT_MULTILINE_DICTIONARY_STRING_CASE;
+        "formats multiline dictionary string value"
+    )]
+    #[test_case(
+        &ION_FORMAT_MULTILINE_DICTIONARY_STRING_WITH_SINGLELINE_STYLE_CASE;
+        "formats multiline dictionary string with singleline style option"
+    )]
+    #[test_case(
+        &ION_FORMAT_MULTILINE_DICTIONARY_STRING_WITH_MULTILINE_STYLE_CASE;
+        "formats multiline dictionary string with multiline style option"
+    )]
     fn format_ion_document(case: &IonFormatTestCase) {
         let ion = case.raw.parse::<Ion>().unwrap();
-        assert_eq!(case.expected, format_ion(&ion));
-        assert_eq!(case.expected, display(&ion).to_string());
+        assert_eq!(case.expected, format_ion_with_options(&ion, case.options));
+        assert_eq!(
+            case.expected,
+            display_with_options(&ion, case.options).to_string()
+        );
+    }
+
+    static DICTIONARY_DISPLAY_SINGLELINE_CASE: LazyLock<DictionaryDisplayTestCase> =
+        LazyLock::new(|| DictionaryDisplayTestCase {
+            dictionary: dictionary([("a", string("foo")), ("query", string("\nSELECT 1\n"))]),
+            field: FieldStyle::Singleline,
+            expected: "a = \"foo\"\nquery = \"\\nSELECT 1\\n\"\n",
+        });
+    static DICTIONARY_DISPLAY_MULTILINE_CASE: LazyLock<DictionaryDisplayTestCase> =
+        LazyLock::new(|| DictionaryDisplayTestCase {
+            dictionary: dictionary([("a", string("foo")), ("query", string("\nSELECT 1\n"))]),
+            field: FieldStyle::Multiline,
+            expected: "a = \"foo\"\nquery = \"\nSELECT 1\n\"\n",
+        });
+
+    #[test_case(
+        &*DICTIONARY_DISPLAY_SINGLELINE_CASE;
+        "dictionary display with singleline style"
+    )]
+    #[test_case(
+        &*DICTIONARY_DISPLAY_MULTILINE_CASE;
+        "dictionary display with multiline style"
+    )]
+    fn display_dictionary(case: &DictionaryDisplayTestCase) {
+        assert_eq!(
+            case.expected,
+            DictionaryDisplay::new(&case.dictionary, case.field).to_string()
+        );
+    }
+
+    static DICTIONARY_FIELD_NON_STRING_CASE: LazyLock<DictionaryFieldDisplayTestCase> =
+        LazyLock::new(|| DictionaryFieldDisplayTestCase {
+            key: "count",
+            value: Value::Integer(7),
+            field: FieldStyle::Singleline,
+            expected: "count = 7\n",
+        });
+    static DICTIONARY_FIELD_MULTILINE_SINGLELINE_CASE: LazyLock<DictionaryFieldDisplayTestCase> =
+        LazyLock::new(|| DictionaryFieldDisplayTestCase {
+            key: "query",
+            value: string("\nSELECT 1\n"),
+            field: FieldStyle::Singleline,
+            expected: "query = \"\\nSELECT 1\\n\"\n",
+        });
+    static DICTIONARY_FIELD_MULTILINE_MULTILINE_CASE: LazyLock<DictionaryFieldDisplayTestCase> =
+        LazyLock::new(|| DictionaryFieldDisplayTestCase {
+            key: "query",
+            value: string("\nSELECT 1\n"),
+            field: FieldStyle::Multiline,
+            expected: "query = \"\nSELECT 1\n\"\n",
+        });
+
+    #[test_case(&*DICTIONARY_FIELD_NON_STRING_CASE; "dictionary field non string value")]
+    #[test_case(
+        &*DICTIONARY_FIELD_MULTILINE_SINGLELINE_CASE;
+        "dictionary field multiline value with singleline style"
+    )]
+    #[test_case(
+        &*DICTIONARY_FIELD_MULTILINE_MULTILINE_CASE;
+        "dictionary field multiline value with multiline style"
+    )]
+    fn display_dictionary_field(case: &DictionaryFieldDisplayTestCase) {
+        assert_eq!(
+            case.expected,
+            DictionaryFieldDisplay::new(case.key, &case.value, case.field).to_string()
+        );
+    }
+
+    fn render_dictionary_multiline_string(key: &str, text: &str) -> String {
+        struct DictionaryMultilineStringDisplay<'a> {
+            key: &'a str,
+            text: &'a str,
+        }
+
+        impl std::fmt::Display for DictionaryMultilineStringDisplay<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write_dictionary_multiline_string(f, self.key, self.text)
+            }
+        }
+
+        DictionaryMultilineStringDisplay { key, text }.to_string()
+    }
+
+    const WRITE_MULTILINE_DICTIONARY_STRING_EMPTY_CASE: WriteDictionaryMultilineStringTestCase =
+        WriteDictionaryMultilineStringTestCase {
+            key: "query",
+            text: "",
+            expected: "query = \"\"\n",
+        };
+    const WRITE_MULTILINE_DICTIONARY_STRING_MULTILINE_CASE: WriteDictionaryMultilineStringTestCase =
+        WriteDictionaryMultilineStringTestCase {
+            key: "query",
+            text: "\nSELECT 1\nFROM dual\n",
+            expected: "query = \"\nSELECT 1\nFROM dual\n\"\n",
+        };
+    const WRITE_MULTILINE_DICTIONARY_STRING_ESCAPES_QUOTE_CASE:
+        WriteDictionaryMultilineStringTestCase = WriteDictionaryMultilineStringTestCase {
+        key: "query",
+        text: "value \"quoted\"",
+        expected: "query = \"value \\\"quoted\\\"\"\n",
+    };
+    const WRITE_MULTILINE_DICTIONARY_STRING_ESCAPES_BACKSLASH_CASE:
+        WriteDictionaryMultilineStringTestCase = WriteDictionaryMultilineStringTestCase {
+        key: "query",
+        text: r"C:\work\ion",
+        expected: "query = \"C:\\\\work\\\\ion\"\n",
+    };
+    const WRITE_MULTILINE_DICTIONARY_STRING_ESCAPES_QUOTE_AND_BACKSLASH_CASE:
+        WriteDictionaryMultilineStringTestCase = WriteDictionaryMultilineStringTestCase {
+        key: "query",
+        text: "path=\"C:\\work\"\n-- done",
+        expected: "query = \"path=\\\"C:\\\\work\\\"\n-- done\"\n",
+    };
+
+    #[test_case(
+        &WRITE_MULTILINE_DICTIONARY_STRING_EMPTY_CASE;
+        "writes empty multiline dictionary string"
+    )]
+    #[test_case(
+        &WRITE_MULTILINE_DICTIONARY_STRING_MULTILINE_CASE;
+        "preserves multiline text and trailing newline"
+    )]
+    #[test_case(
+        &WRITE_MULTILINE_DICTIONARY_STRING_ESCAPES_QUOTE_CASE;
+        "escapes quotes in multiline dictionary string"
+    )]
+    #[test_case(
+        &WRITE_MULTILINE_DICTIONARY_STRING_ESCAPES_BACKSLASH_CASE;
+        "escapes backslashes in multiline dictionary string"
+    )]
+    #[test_case(
+        &WRITE_MULTILINE_DICTIONARY_STRING_ESCAPES_QUOTE_AND_BACKSLASH_CASE;
+        "escapes quotes and backslashes while preserving newlines"
+    )]
+    fn write_dictionary_multiline_string_cases(case: &WriteDictionaryMultilineStringTestCase) {
+        assert_eq!(
+            case.expected,
+            render_dictionary_multiline_string(case.key, case.text)
+        );
     }
 
     static SEPARATOR_ROW_CASE: LazyLock<DataOrSeparatorTestCase> =

--- a/ion-fmt/src/error.rs
+++ b/ion-fmt/src/error.rs
@@ -3,8 +3,9 @@ use std::fmt;
 
 /// Error returned by file-based formatting operations.
 ///
-/// String-based helpers such as [`crate::format_str`] return `ion::IonError`
-/// directly. File-based helpers wrap both I/O and parse failures in this type.
+/// String-based helpers such as [`crate::format_str_with_options`] return
+/// `ion::IonError` directly. File-based helpers wrap both I/O and parse
+/// failures in this type.
 #[derive(Debug)]
 pub enum FormatError {
     /// Filesystem read/write error.

--- a/ion-fmt/src/lib.rs
+++ b/ion-fmt/src/lib.rs
@@ -12,41 +12,51 @@
 //!
 //! # Main entry points
 //!
-//! - [`format_str`] formats a raw Ion string
-//! - [`check_str`] checks whether a raw Ion string is already formatted
-//! - [`format_file`] formats a file without rewriting it
-//! - [`write_formatted_file`] rewrites a file in place when formatting changes it
-//! - [`display`] and [`format_ion`] operate on a pre-parsed [`ion::Ion`] value
+//! - [`format_str_with_options`] formats a raw Ion string with explicit style options
+//! - [`check_str_with_options`] checks whether a raw Ion string is already formatted
+//! - [`format_file_with_options`] formats a file without rewriting it
+//! - [`write_formatted_file_with_options`] rewrites a file in place when formatting changes it
+//! - [`display_with_options`] and [`format_ion_with_options`] operate on a pre-parsed [`ion::Ion`] value
+//! - [`DictionaryDisplay`] and [`DictionaryFieldDisplay`] render dictionary-only output
+//! - [`FormatOptions`] controls style decisions such as dictionary string rendering
 //!
 //! # Examples
 //!
 //! Formatting a string:
 //!
 //! ```rust
-//! use ion_fmt::format_str;
+//! use ion_fmt::{FormatOptions, format_str_with_options};
 //!
 //! let raw = "[A]\n[B]\n";
-//! let formatted = format_str(raw).unwrap();
+//! let formatted = format_str_with_options(raw, FormatOptions::default()).unwrap();
 //! assert_eq!("[A]\n\n[B]\n\n", formatted);
 //! ```
 //!
 //! Checking formatting:
 //!
 //! ```rust
-//! use ion_fmt::check_str;
+//! use ion_fmt::{FormatOptions, check_str_with_options};
 //!
-//! assert!(!check_str("[A]\n[B]\n").unwrap());
-//! assert!(check_str("[A]\n\n[B]\n\n").unwrap());
+//! assert!(!check_str_with_options("[A]\n[B]\n", FormatOptions::default()).unwrap());
+//! assert!(check_str_with_options("[A]\n\n[B]\n\n", FormatOptions::default()).unwrap());
 //! ```
 //!
 //! Formatting a parsed document:
 //!
 //! ```rust
 //! use ion::Ion;
-//! use ion_fmt::format_ion;
+//! use ion_fmt::{DictionaryOptions, FieldStyle, FormatOptions, format_ion_with_options};
 //!
 //! let ion: Ion = "[A]\n[B]\n".parse().unwrap();
-//! assert_eq!("[A]\n\n[B]\n\n", format_ion(&ion));
+//! let formatted = format_ion_with_options(
+//!     &ion,
+//!     FormatOptions {
+//!         dictionary: DictionaryOptions {
+//!             field: FieldStyle::Singleline,
+//!         },
+//!     },
+//! );
+//! assert_eq!("[A]\n\n[B]\n\n", formatted);
 //! ```
 #![warn(missing_docs)]
 
@@ -55,7 +65,10 @@ mod display;
 mod error;
 
 /// Display wrapper and helpers used to render formatted Ion output.
-pub use display::{IonDisplay, display, format_ion};
+pub use display::{
+    DictionaryDisplay, DictionaryFieldDisplay, DictionaryOptions, FieldStyle, FormatOptions,
+    IonDisplay, display_with_options, format_ion_with_options,
+};
 /// Error type returned by file-oriented formatting APIs.
 pub use error::FormatError;
 
@@ -63,7 +76,7 @@ use ion::Ion;
 use std::fs;
 use std::path::Path;
 
-/// Result returned by [`format_file`].
+/// Result returned by [`format_file_with_options`].
 ///
 /// This lets callers inspect the formatted bytes before deciding whether to
 /// write them back to disk.
@@ -75,7 +88,7 @@ pub struct FormatResult {
     pub changed: bool,
 }
 
-/// Formats an Ion string into canonical `ion-fmt` output.
+/// Formats an Ion string using explicit formatting options.
 ///
 /// This keeps section ordering from parsed [`Ion`] and aligns table columns.
 ///
@@ -87,46 +100,57 @@ pub struct FormatResult {
 /// # Errors
 ///
 /// Returns parser errors when `raw` is not a valid Ion document.
-pub fn format_str(raw: &str) -> Result<String, ion::IonError> {
-    raw.parse::<Ion>().map(|ion| format_ion(&ion))
+pub fn format_str_with_options(raw: &str, options: FormatOptions) -> Result<String, ion::IonError> {
+    raw.parse::<Ion>()
+        .map(|ion| format_ion_with_options(&ion, options))
 }
 
-/// Checks whether an Ion string is already formatted.
+/// Checks whether an Ion string is already formatted for explicit options.
 ///
-/// Returns `Ok(true)` when [`format_str`] would return exactly the same bytes.
+/// Returns `Ok(true)` when [`format_str_with_options`] would return exactly
+/// the same bytes.
 ///
 /// # Errors
 ///
 /// Returns parser errors when `raw` is not a valid Ion document.
-pub fn check_str(raw: &str) -> Result<bool, ion::IonError> {
-    Ok(format_str(raw)? == raw)
+pub fn check_str_with_options(raw: &str, options: FormatOptions) -> Result<bool, ion::IonError> {
+    Ok(format_str_with_options(raw, options)? == raw)
 }
 
-/// Reads a file, formats its content, and reports if any change is needed.
+/// Reads a file, formats its content with explicit options, and reports if any
+/// change is needed.
 ///
 /// This function does not write to disk.
 ///
 /// # Errors
 ///
-/// Returns I/O errors when the file cannot be read and parser errors when its content is invalid Ion.
-pub fn format_file(path: impl AsRef<Path>) -> Result<FormatResult, FormatError> {
+/// Returns I/O errors when the file cannot be read and parser errors when its
+/// content is invalid Ion.
+pub fn format_file_with_options(
+    path: impl AsRef<Path>,
+    options: FormatOptions,
+) -> Result<FormatResult, FormatError> {
     let raw = fs::read_to_string(path.as_ref())?;
-    let formatted = format_str(&raw)?;
+    let formatted = format_str_with_options(&raw, options)?;
     let changed = raw != formatted;
 
     Ok(FormatResult { formatted, changed })
 }
 
-/// Formats a file in place.
+/// Formats a file in place using explicit formatting options.
 ///
 /// Returns `Ok(true)` when the file was rewritten with formatted content.
 ///
 /// # Errors
 ///
-/// Returns I/O errors when the file cannot be read/written and parser errors when its content is invalid Ion.
-pub fn write_formatted_file(path: impl AsRef<Path>) -> Result<bool, FormatError> {
+/// Returns I/O errors when the file cannot be read/written and parser errors
+/// when its content is invalid Ion.
+pub fn write_formatted_file_with_options(
+    path: impl AsRef<Path>,
+    options: FormatOptions,
+) -> Result<bool, FormatError> {
     let path = path.as_ref();
-    let result = format_file(path)?;
+    let result = format_file_with_options(path, options)?;
 
     if result.changed {
         fs::write(path, result.formatted)?;
@@ -137,7 +161,10 @@ pub fn write_formatted_file(path: impl AsRef<Path>) -> Result<bool, FormatError>
 
 #[cfg(test)]
 mod tests {
-    use super::{FormatResult, check_str, format_file, format_str, write_formatted_file};
+    use super::{
+        DictionaryOptions, FieldStyle, FormatOptions, FormatResult, check_str_with_options,
+        format_file_with_options, format_str_with_options, write_formatted_file_with_options,
+    };
     use indoc::indoc;
     use pretty_assertions::assert_eq;
     use std::fs;
@@ -147,6 +174,13 @@ mod tests {
     #[derive(Debug)]
     struct FormatStringTestCase {
         raw: &'static str,
+        expected: &'static str,
+    }
+
+    #[derive(Debug)]
+    struct FormatStringWithOptionsTestCase {
+        raw: &'static str,
+        options: FormatOptions,
         expected: &'static str,
     }
 
@@ -177,10 +211,135 @@ mod tests {
 
             "#},
         });
+    static FORMAT_MULTILINE_DICTIONARY_STRING_CASE: LazyLock<FormatStringTestCase> =
+        LazyLock::new(|| FormatStringTestCase {
+            raw: indoc! {r#"
+                [Data]
+                select = "
+                    SELECT column
+                    FROM table t1
+                    INNER JOIN t2
+                        ON t1.id = t2.
+                    WHERE t1.userid = {{ user_id }}
+                    ORDER BY name ASC
+                "
+
+                [Table]
+                |   col1   |
+                |--------|
+                | name1 |
+                | name2 |
+            "#},
+            expected: indoc! {r#"
+                [Data]
+                select = "
+                    SELECT column
+                    FROM table t1
+                    INNER JOIN t2
+                        ON t1.id = t2.
+                    WHERE t1.userid = {{ user_id }}
+                    ORDER BY name ASC
+                "
+
+                [Table]
+                |  col1 |
+                |-------|
+                | name1 |
+                | name2 |
+
+            "#},
+        });
 
     #[test_case(&*FORMAT_STRING_CASE; "formats string input")]
-    fn format_string(case: &FormatStringTestCase) {
-        assert_eq!(case.expected, format_str(case.raw).unwrap());
+    #[test_case(
+        &*FORMAT_MULTILINE_DICTIONARY_STRING_CASE;
+        "formats multiline dictionary string value"
+    )]
+    fn default_format(case: &FormatStringTestCase) {
+        assert_eq!(
+            case.expected,
+            format_str_with_options(case.raw, FormatOptions::default()).unwrap()
+        );
+    }
+
+    const FORMAT_MULTILINE_DICTIONARY_STRING_WITH_MULTILINE_STYLE_CASE:
+        FormatStringWithOptionsTestCase = FormatStringWithOptionsTestCase {
+        raw: indoc! {r#"
+                [Data]
+                select = "
+                    SELECT column
+                    FROM table t1
+                    INNER JOIN t2
+                        ON t1.id = t2.
+                    WHERE t1.userid = {{ user_id }}
+                    ORDER BY name ASC
+                "
+
+                [Table]
+                |   col1   |
+                |--------|
+                | name1 |
+                | name2 |
+            "#},
+        options: FormatOptions {
+            dictionary: DictionaryOptions {
+                field: FieldStyle::Multiline,
+            },
+        },
+        expected: indoc! {r#"
+                [Data]
+                select = "
+                    SELECT column
+                    FROM table t1
+                    INNER JOIN t2
+                        ON t1.id = t2.
+                    WHERE t1.userid = {{ user_id }}
+                    ORDER BY name ASC
+                "
+
+                [Table]
+                |  col1 |
+                |-------|
+                | name1 |
+                | name2 |
+
+            "#},
+    };
+
+    const FORMAT_MULTILINE_DICTIONARY_STRING_WITH_SINGLELINE_STYLE_CASE:
+        FormatStringWithOptionsTestCase = FormatStringWithOptionsTestCase {
+        options: FormatOptions {
+            dictionary: DictionaryOptions {
+                field: FieldStyle::Singleline,
+            },
+        },
+        expected: indoc! {r#"
+                [Data]
+                select = "\n    SELECT column\n    FROM table t1\n    INNER JOIN t2\n        ON t1.id = t2.\n    WHERE t1.userid = {{ user_id }}\n    ORDER BY name ASC\n"
+
+                [Table]
+                |  col1 |
+                |-------|
+                | name1 |
+                | name2 |
+
+            "#},
+        ..FORMAT_MULTILINE_DICTIONARY_STRING_WITH_MULTILINE_STYLE_CASE
+    };
+
+    #[test_case(
+        &FORMAT_MULTILINE_DICTIONARY_STRING_WITH_MULTILINE_STYLE_CASE;
+        "formats multiline dictionary string value with multiline style option"
+    )]
+    #[test_case(
+        &FORMAT_MULTILINE_DICTIONARY_STRING_WITH_SINGLELINE_STYLE_CASE;
+        "formats multiline dictionary string value with singleline style option"
+    )]
+    fn format_with_options_cases(case: &FormatStringWithOptionsTestCase) {
+        assert_eq!(
+            case.expected,
+            format_str_with_options(case.raw, case.options).unwrap()
+        );
     }
 
     static CHECK_FALSE_CASE: LazyLock<CheckStringTestCase> =
@@ -200,11 +359,69 @@ mod tests {
         "},
         expected_is_formatted: true,
     });
+    static CHECK_MULTILINE_DICTIONARY_STRING_CASE: LazyLock<CheckStringTestCase> =
+        LazyLock::new(|| CheckStringTestCase {
+            raw: indoc! {r#"
+                [Data]
+                select = "
+                    SELECT column
+                    FROM table t1
+                    INNER JOIN t2
+                        ON t1.id = t2.
+                    WHERE t1.userid = {{ user_id }}
+                    ORDER BY name ASC
+                "
+
+                [Table]
+                |  col1 |
+                |-------|
+                | name1 |
+                | name2 |
+
+            "#},
+            expected_is_formatted: true,
+        });
 
     #[test_case(&*CHECK_FALSE_CASE; "not formatted")]
     #[test_case(&*CHECK_TRUE_CASE; "already formatted")]
-    fn check_string(case: &CheckStringTestCase) {
-        assert_eq!(case.expected_is_formatted, check_str(case.raw).unwrap());
+    #[test_case(
+        &*CHECK_MULTILINE_DICTIONARY_STRING_CASE;
+        "multiline dictionary string already formatted"
+    )]
+    fn default_check(case: &CheckStringTestCase) {
+        assert_eq!(
+            case.expected_is_formatted,
+            check_str_with_options(case.raw, FormatOptions::default()).unwrap()
+        );
+    }
+
+    #[test]
+    fn check_string_with_options_multiline_style() {
+        let raw = indoc! {r#"
+            [Data]
+            select = "
+                SELECT column
+                FROM table t1
+                INNER JOIN t2
+                    ON t1.id = t2.
+                WHERE t1.userid = {{ user_id }}
+                ORDER BY name ASC
+            "
+
+            [Table]
+            |  col1 |
+            |-------|
+            | name1 |
+            | name2 |
+
+        "#};
+        let options = FormatOptions {
+            dictionary: DictionaryOptions {
+                field: FieldStyle::Multiline,
+            },
+        };
+
+        assert_eq!(true, check_str_with_options(raw, options).unwrap());
     }
 
     #[test]
@@ -223,7 +440,7 @@ mod tests {
         "};
         fs::write(&temp_path, raw).unwrap();
 
-        let result = format_file(&temp_path).unwrap();
+        let result = format_file_with_options(&temp_path, FormatOptions::default()).unwrap();
         assert_eq!(
             FormatResult {
                 formatted: indoc! {r"
@@ -238,7 +455,10 @@ mod tests {
             result
         );
 
-        assert_eq!(true, write_formatted_file(&temp_path).unwrap());
+        assert_eq!(
+            true,
+            write_formatted_file_with_options(&temp_path, FormatOptions::default()).unwrap()
+        );
         assert_eq!(
             indoc! {r"
                 [X]

--- a/ion-fmt/src/main.rs
+++ b/ion-fmt/src/main.rs
@@ -12,9 +12,13 @@
 //! - `IsTerminal` distinguishes those cases, but it does not tell us whether any bytes are ready
 
 use clap::{Parser, Subcommand};
-use ion_fmt::{format_file, format_str, write_formatted_file};
+use ion_fmt::{
+    DictionaryOptions, FieldStyle, FormatOptions, format_file_with_options,
+    format_str_with_options, write_formatted_file_with_options,
+};
 use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 #[cfg(feature = "dictionary-indexmap")]
 const CLI_ABOUT: &str = "Formats Ion files.";
@@ -46,9 +50,39 @@ enum CliExitCode {
     Failure = 1,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StyleOption {
+    DictionaryField(FieldStyle),
+}
+
+impl FromStr for StyleOption {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (key, value) = s
+            .split_once('=')
+            .ok_or_else(|| format!("Invalid `--style` value `{s}`. Expected `key=value`."))?;
+
+        match key {
+            "dictionary-field" => value.parse().map(Self::DictionaryField),
+            _ => Err(format!(
+                "Unsupported `--style` key `{key}`. Supported keys: `dictionary-field`."
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(name = "ion-fmt", version, about = CLI_ABOUT, long_about = CLI_LONG_ABOUT)]
 struct Cli {
+    /// Style options in `key=value` form (repeatable).
+    ///
+    /// Supported:
+    /// - `dictionary-field=multiline` (default)
+    /// - `dictionary-field=singleline`
+    #[arg(long = "style", value_name = "KEY=VALUE", global = true)]
+    styles: Vec<StyleOption>,
+
     #[command(subcommand)]
     command: Option<CliCommand>,
 }
@@ -103,20 +137,31 @@ fn stdin_is_terminal() -> bool {
 /// A bare `ion-fmt` invocation maps to the `stdout` mode. Whether it then reads
 /// stdin or returns an error depends on the terminal check in `resolve_input_kind`.
 fn run_with_cli(parsed: &Cli, stdin_is_terminal: bool) -> Result<CliExitCode, String> {
+    let options = parsed.format_options();
+
     match parsed.command.as_ref() {
         Some(CliCommand::Format { paths }) => {
-            run_mode(paths, Mode::FormatInPlace, stdin_is_terminal)
+            run_mode(paths, Mode::FormatInPlace, stdin_is_terminal, options)
         }
-        Some(CliCommand::Check { paths }) => run_mode(paths, Mode::Check, stdin_is_terminal),
-        Some(CliCommand::Stdout { paths }) => run_mode(paths, Mode::Stdout, stdin_is_terminal),
-        None => run_mode(&[], Mode::Stdout, stdin_is_terminal),
+        Some(CliCommand::Check { paths }) => {
+            run_mode(paths, Mode::Check, stdin_is_terminal, options)
+        }
+        Some(CliCommand::Stdout { paths }) => {
+            run_mode(paths, Mode::Stdout, stdin_is_terminal, options)
+        }
+        None => run_mode(&[], Mode::Stdout, stdin_is_terminal, options),
     }
 }
 
-fn run_mode(paths: &[PathBuf], mode: Mode, stdin_is_terminal: bool) -> Result<CliExitCode, String> {
+fn run_mode(
+    paths: &[PathBuf],
+    mode: Mode,
+    stdin_is_terminal: bool,
+    options: FormatOptions,
+) -> Result<CliExitCode, String> {
     match resolve_input_kind(paths, stdin_is_terminal) {
-        Some(InputKind::Stdin) => run_with_stdin(mode),
-        Some(InputKind::Paths) => Ok(run_with_paths(paths, mode)),
+        Some(InputKind::Stdin) => run_with_stdin(mode, options),
+        Some(InputKind::Paths) => Ok(run_with_paths(paths, mode, options)),
         None => Err(missing_input_error(mode)),
     }
 }
@@ -143,13 +188,13 @@ fn resolve_input_kind(paths: &[PathBuf], stdin_is_terminal: bool) -> Option<Inpu
 }
 
 /// Runs formatter against stdin for a selected mode.
-fn run_with_stdin(mode: Mode) -> Result<CliExitCode, String> {
+fn run_with_stdin(mode: Mode, options: FormatOptions) -> Result<CliExitCode, String> {
     let mut raw = String::new();
     io::stdin()
         .read_to_string(&mut raw)
         .map_err(|error| format!("Failed to read stdin: {error}"))?;
 
-    let formatted = format_str(&raw).map_err(|error| format!("{error}"))?;
+    let formatted = format_str_with_options(&raw, options).map_err(|error| format!("{error}"))?;
     let needs_formatting = formatted != raw;
 
     if mode == Mode::Check {
@@ -166,13 +211,13 @@ fn run_with_stdin(mode: Mode) -> Result<CliExitCode, String> {
 }
 
 /// Runs formatter over file paths for a selected mode.
-fn run_with_paths(paths: &[PathBuf], mode: Mode) -> CliExitCode {
+fn run_with_paths(paths: &[PathBuf], mode: Mode, options: FormatOptions) -> CliExitCode {
     let mut has_errors = false;
     let mut needs_formatting = false;
 
     for path in paths {
         match mode {
-            Mode::Stdout => match format_file(path) {
+            Mode::Stdout => match format_file_with_options(path, options) {
                 Ok(result) => {
                     if paths.len() > 1 {
                         println!("==> {} <==", path.display());
@@ -184,7 +229,7 @@ fn run_with_paths(paths: &[PathBuf], mode: Mode) -> CliExitCode {
                     eprintln!("{}: {error}", path.display());
                 }
             },
-            Mode::Check => match format_file(path) {
+            Mode::Check => match format_file_with_options(path, options) {
                 Ok(result) => {
                     if result.changed {
                         needs_formatting = true;
@@ -197,7 +242,7 @@ fn run_with_paths(paths: &[PathBuf], mode: Mode) -> CliExitCode {
                 }
             },
             Mode::FormatInPlace => {
-                if let Err(error) = write_formatted_file(path) {
+                if let Err(error) = write_formatted_file_with_options(path, options) {
                     has_errors = true;
                     eprintln!("{}: {error}", path.display());
                 }
@@ -238,12 +283,30 @@ impl CliExitCode {
     }
 }
 
+impl Cli {
+    #[must_use]
+    fn format_options(&self) -> FormatOptions {
+        let mut field = FieldStyle::Multiline;
+
+        for option in &self.styles {
+            match option {
+                StyleOption::DictionaryField(next_style) => field = *next_style,
+            }
+        }
+
+        FormatOptions {
+            dictionary: DictionaryOptions { field },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, CliCommand, CliExitCode, InputKind, Mode, missing_input_error, resolve_input_kind,
-        run_with_cli,
+        Cli, CliCommand, CliExitCode, FieldStyle, InputKind, Mode, missing_input_error,
+        resolve_input_kind, run_with_cli,
     };
+    use clap::Parser;
     use pretty_assertions::assert_eq;
     use std::path::PathBuf;
     use std::sync::LazyLock;
@@ -300,13 +363,17 @@ mod tests {
 
     static DEFAULT_COMMAND_MISSING_INPUT_CASE: LazyLock<RunWithCliTestCase> =
         LazyLock::new(|| RunWithCliTestCase {
-            cli: Cli { command: None },
+            cli: Cli {
+                styles: vec![],
+                command: None,
+            },
             stdin_is_terminal: true,
             expected: RunWithCliExpectation::Error(missing_input_error(Mode::Stdout)),
         });
     static FORMAT_COMMAND_MISSING_INPUT_CASE: LazyLock<RunWithCliTestCase> =
         LazyLock::new(|| RunWithCliTestCase {
             cli: Cli {
+                styles: vec![],
                 command: Some(CliCommand::Format { paths: vec![] }),
             },
             stdin_is_terminal: true,
@@ -315,6 +382,7 @@ mod tests {
     static CHECK_COMMAND_MISSING_INPUT_CASE: LazyLock<RunWithCliTestCase> =
         LazyLock::new(|| RunWithCliTestCase {
             cli: Cli {
+                styles: vec![],
                 command: Some(CliCommand::Check { paths: vec![] }),
             },
             stdin_is_terminal: true,
@@ -323,6 +391,7 @@ mod tests {
     static STDOUT_COMMAND_MISSING_INPUT_CASE: LazyLock<RunWithCliTestCase> =
         LazyLock::new(|| RunWithCliTestCase {
             cli: Cli {
+                styles: vec![],
                 command: Some(CliCommand::Stdout { paths: vec![] }),
             },
             stdin_is_terminal: true,
@@ -331,6 +400,7 @@ mod tests {
     static CHECK_FORMATTED_FILE_CASE: LazyLock<RunWithCliTestCase> =
         LazyLock::new(|| RunWithCliTestCase {
             cli: Cli {
+                styles: vec![],
                 command: Some(CliCommand::Check {
                     paths: vec![PathBuf::from("tests/readme/formatted.ion")],
                 }),
@@ -341,6 +411,7 @@ mod tests {
     static CHECK_UNFORMATTED_FILE_CASE: LazyLock<RunWithCliTestCase> =
         LazyLock::new(|| RunWithCliTestCase {
             cli: Cli {
+                styles: vec![],
                 command: Some(CliCommand::Check {
                     paths: vec![PathBuf::from("tests/readme/unformatted.ion")],
                 }),
@@ -362,5 +433,89 @@ mod tests {
         };
 
         assert_eq!(case.expected, actual);
+    }
+
+    #[derive(Debug)]
+    struct ParseStyleCliTestCase {
+        args: Vec<&'static str>,
+        expected_style: Option<FieldStyle>,
+        expected_error_fragment: Option<&'static str>,
+    }
+
+    static STYLE_DEFAULT_CASE: LazyLock<ParseStyleCliTestCase> =
+        LazyLock::new(|| ParseStyleCliTestCase {
+            args: vec!["ion-fmt"],
+            expected_style: Some(FieldStyle::Multiline),
+            expected_error_fragment: None,
+        });
+    static STYLE_SINGLELINE_CASE: LazyLock<ParseStyleCliTestCase> =
+        LazyLock::new(|| ParseStyleCliTestCase {
+            args: vec!["ion-fmt", "--style", "dictionary-field=singleline"],
+            expected_style: Some(FieldStyle::Singleline),
+            expected_error_fragment: None,
+        });
+    static STYLE_MULTILINE_CASE: LazyLock<ParseStyleCliTestCase> =
+        LazyLock::new(|| ParseStyleCliTestCase {
+            args: vec!["ion-fmt", "--style", "dictionary-field=multiline"],
+            expected_style: Some(FieldStyle::Multiline),
+            expected_error_fragment: None,
+        });
+    static STYLE_LAST_WINS_CASE: LazyLock<ParseStyleCliTestCase> =
+        LazyLock::new(|| ParseStyleCliTestCase {
+            args: vec![
+                "ion-fmt",
+                "--style",
+                "dictionary-field=singleline",
+                "--style",
+                "dictionary-field=multiline",
+            ],
+            expected_style: Some(FieldStyle::Multiline),
+            expected_error_fragment: None,
+        });
+    static STYLE_MISSING_VALUE_CASE: LazyLock<ParseStyleCliTestCase> =
+        LazyLock::new(|| ParseStyleCliTestCase {
+            args: vec!["ion-fmt", "--style", "dictionary-field"],
+            expected_style: None,
+            expected_error_fragment: Some("Expected `key=value`"),
+        });
+    static STYLE_UNKNOWN_KEY_CASE: LazyLock<ParseStyleCliTestCase> =
+        LazyLock::new(|| ParseStyleCliTestCase {
+            args: vec!["ion-fmt", "--style", "table-column=singleline"],
+            expected_style: None,
+            expected_error_fragment: Some("Supported keys: `dictionary-field`"),
+        });
+    static STYLE_UNKNOWN_VALUE_CASE: LazyLock<ParseStyleCliTestCase> =
+        LazyLock::new(|| ParseStyleCliTestCase {
+            args: vec!["ion-fmt", "--style", "dictionary-field=folded"],
+            expected_style: None,
+            expected_error_fragment: Some("Expected `singleline` or `multiline`"),
+        });
+
+    #[test_case(&*STYLE_DEFAULT_CASE; "default style is multiline")]
+    #[test_case(&*STYLE_SINGLELINE_CASE; "parses explicit singleline")]
+    #[test_case(&*STYLE_MULTILINE_CASE; "parses multiline")]
+    #[test_case(&*STYLE_LAST_WINS_CASE; "last style wins when repeated")]
+    #[test_case(&*STYLE_MISSING_VALUE_CASE; "rejects style missing value")]
+    #[test_case(&*STYLE_UNKNOWN_KEY_CASE; "rejects unknown style key")]
+    #[test_case(&*STYLE_UNKNOWN_VALUE_CASE; "rejects unknown dictionary-field style value")]
+    fn parse_style_cli_cases(case: &ParseStyleCliTestCase) {
+        match Cli::try_parse_from(case.args.clone()) {
+            Ok(cli) => {
+                assert_eq!(case.expected_error_fragment, None);
+                assert_eq!(
+                    case.expected_style,
+                    Some(cli.format_options().dictionary.field)
+                );
+            }
+            Err(error) => {
+                let rendered = error.to_string();
+                assert_eq!(case.expected_style, None);
+                assert!(
+                    case.expected_error_fragment
+                        .is_some_and(|fragment| rendered.contains(fragment)),
+                    "actual CLI parse error: {rendered}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
- add `FormatOptions` + `DirectoryOptions` + `FieldStyle`
- add public `DictionaryDisplay` and `DictionaryFieldDisplay`
- add CLI `--style dictionary-field=singleline|multiline` (default: `multiline`)
- replace wrapper APIs with `*_with_options` variants
- update tests/docs/changelog and bump `ion-fmt` to `0.13.0`

`BREAKING CHANGE: 
* removed format_str/check_str/format_file/write_formatted_file/display/format_ion; use *_with_options replacements.`