### PR TITLE
release(ion)!: prepare 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["ion", "ion-fmt"]
 resolver = "2"
 
 [workspace.dependencies]
-ion = { version = "0.12.0", path = "ion" }
+ion = { version = "0.13.0", path = "ion" }
 
 # crates.io
 clap = { version = "4.6", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Default ordered backend (`BTreeMap` for sections and dictionaries):
 
 ```toml
 [dependencies]
-ion = "0.12.0"
+ion = "0.13.0"
 ```
 
 Insertion-ordered backend (`IndexMap` for sections and dictionaries):
 
 ```toml
 [dependencies]
-ion = { version = "0.12.0", features = ["dictionary-indexmap"] }
+ion = { version = "0.13.0", features = ["dictionary-indexmap"] }
 ```
 
 ## Related Crates

--- a/ion-fmt/src/display.rs
+++ b/ion-fmt/src/display.rs
@@ -528,7 +528,7 @@ mod tests {
     fn dictionary(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Dictionary {
         let mut dictionary = Dictionary::new();
         for (key, value) in entries {
-            dictionary.insert(key.to_owned(), value);
+            dictionary.insert(key.into(), value);
         }
         dictionary
     }

--- a/ion/CHANGELOG.md
+++ b/ion/CHANGELOG.md
@@ -5,6 +5,19 @@ Repository and workspace maintenance changes are intentionally omitted.
 
 ## Unreleased
 
+## 0.13.0
+
+### Changed
+
+- Store `Dictionary` and top-level `Sections` keys as `Box<str>` to reduce per-key overhead
+
+### Breaking changes
+
+- `Dictionary` is now `BTreeMap<Box<str>, Value>` (or `IndexMap<Box<str>, Value>` with `dictionary-indexmap`)
+- `Sections` is now `BTreeMap<Box<str>, Section>` (or `IndexMap<Box<str>, Section>` with `dictionary-indexmap`)
+- `Ion::get_key_value()` now returns `Option<(&str, &Section)>`
+- `Ion::iter()` now yields `(&str, &Section)`
+
 ## 0.12.0
 
 ### Changed

--- a/ion/Cargo.toml
+++ b/ion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion"
-version = "0.12.0"
+version = "0.13.0"
 description = "*.ion file parser"
 edition = "2024"
 license = "MIT"

--- a/ion/README.md
+++ b/ion/README.md
@@ -23,14 +23,14 @@ Default ordered backend (`BTreeMap` for sections and dictionaries):
 
 ```toml
 [dependencies]
-ion = "0.12.0"
+ion = "0.13.0"
 ```
 
 Insertion-ordered backend (`IndexMap` for sections and dictionaries):
 
 ```toml
 [dependencies]
-ion = { version = "0.12.0", features = ["dictionary-indexmap"] }
+ion = { version = "0.13.0", features = ["dictionary-indexmap"] }
 ```
 
 ## Rust Quick Start

--- a/ion/src/ion.rs
+++ b/ion/src/ion.rs
@@ -57,18 +57,20 @@ impl Ion {
     ///
     /// This method attempts to find a section by its key within the collection of sections.
     /// If the section exists, it returns an `Option` containing a tuple of the key as a
-    /// reference to a `String` and the value as a reference to a `Section`. If the key
+    /// reference to a string slice and the value as a reference to a `Section`. If the key
     /// does not exist within the sections, it returns `None`.
     ///
     /// # Returns
     ///
-    /// Returns `Option<(&String, &Section)>`. If the key is found, the return value is
-    /// `Some((&String, &Section))`, where the first element is a reference to the key
+    /// Returns `Option<(&str, &Section)>`. If the key is found, the return value is
+    /// `Some((&str, &Section))`, where the first element is a reference to the key
     /// and the second element is a reference to the corresponding `Section`. If the key
     /// is not found, it returns `None`.
     #[must_use]
-    pub fn get_key_value(&self, key: &str) -> Option<(&String, &Section)> {
-        self.sections.get_key_value(key)
+    pub fn get_key_value(&self, key: &str) -> Option<(&str, &Section)> {
+        self.sections
+            .get_key_value(key)
+            .map(|(name, section)| (name.as_ref(), section))
     }
 
     /// # Errors
@@ -95,8 +97,10 @@ impl Ion {
     }
 
     /// Iterates over section name / section pairs.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Section)> {
-        self.sections.iter()
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Section)> {
+        self.sections
+            .iter()
+            .map(|(name, section)| (name.as_ref(), section))
     }
 }
 
@@ -188,7 +192,7 @@ mod tests {
     fn section(entries: Vec<(&str, Value)>) -> Section {
         let mut section = Section::new();
         for (key, value) in entries {
-            section.dictionary.insert(key.to_owned(), value);
+            section.dictionary.insert(key.into(), value);
         }
         section
     }
@@ -196,7 +200,7 @@ mod tests {
     fn sections(entries: Vec<(&str, Section)>) -> Sections {
         let mut sections = Sections::new();
         for (name, section) in entries {
-            sections.insert(name.to_owned(), section);
+            sections.insert(name.into(), section);
         }
         sections
     }
@@ -366,7 +370,7 @@ mod tests {
             Some(section) => {
                 section
                     .dictionary
-                    .insert("name".to_owned(), Value::new_string("bar"));
+                    .insert("name".into(), Value::new_string("bar"));
             }
             None => panic!("expected section"),
         }

--- a/ion/src/ion/display.rs
+++ b/ion/src/ion/display.rs
@@ -148,7 +148,7 @@ mod tests {
     fn section(entries: Vec<(&str, Value)>, rows: Vec<Vec<Value>>) -> Section {
         let mut section = Section::new();
         for (key, value) in entries {
-            section.dictionary.insert(key.to_owned(), value);
+            section.dictionary.insert(key.into(), value);
         }
         section.rows = rows;
         section
@@ -157,7 +157,7 @@ mod tests {
     fn sections(entries: Vec<(&str, Section)>) -> crate::Sections {
         let mut sections = crate::Sections::new();
         for (name, section) in entries {
-            sections.insert(name.to_owned(), section);
+            sections.insert(name.into(), section);
         }
         sections
     }
@@ -165,7 +165,7 @@ mod tests {
     fn dictionary(entries: Vec<(&str, Value)>) -> Value {
         let mut dictionary = crate::Dictionary::new();
         for (key, value) in entries {
-            dictionary.insert(key.to_owned(), value);
+            dictionary.insert(key.into(), value);
         }
         Value::Dictionary(dictionary)
     }

--- a/ion/src/ion/section.rs
+++ b/ion/src/ion/section.rs
@@ -421,7 +421,7 @@ mod tests {
         let mut section = Section::with_capacity(2);
         section
             .dictionary
-            .insert("name".to_owned(), Value::new_string("foo"));
+            .insert("name".into(), Value::new_string("foo"));
         section.rows = vec![
             vec![Value::new_string("h1")],
             vec![Value::new_string("---")],
@@ -470,7 +470,7 @@ mod tests {
         let mut section = Section::new();
         section
             .dictionary
-            .insert("name".to_owned(), Value::new_string("foo"));
+            .insert("name".into(), Value::new_string("foo"));
 
         match section.get_mut("name") {
             Some(Value::String(value)) => *value = "bar".into(),

--- a/ion/src/ion/value.rs
+++ b/ion/src/ion/value.rs
@@ -236,7 +236,7 @@ mod tests {
         expected_dictionary_lookup: None,
     });
     static DICTIONARY_HELPER_CASE: LazyLock<HelperTestCase> = LazyLock::new(|| {
-        let dictionary = Dictionary::from([("name".to_owned(), Value::new_string("foo"))]);
+        let dictionary = Dictionary::from([("name".into(), Value::new_string("foo"))]);
         HelperTestCase {
             value: Value::Dictionary(dictionary),
             expected_type: "dictionary",

--- a/ion/src/lib.rs
+++ b/ion/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! let app = ion.get_mut("APP").unwrap();
 //! app.dictionary
-//!     .insert("enabled".to_owned(), Value::Boolean(true));
+//!     .insert("enabled".into(), Value::Boolean(true));
 //!
 //! assert_eq!(Some("demo"), app.get("name").and_then(Value::as_str));
 //! # Ok::<(), ion::IonError>(())
@@ -59,29 +59,29 @@ pub use self::parser::*;
 ///
 /// The concrete map type depends on the `dictionary-indexmap` feature:
 ///
-/// - default: `BTreeMap<String, Value>`
-/// - `dictionary-indexmap`: `IndexMap<String, Value>`
+/// - default: `BTreeMap<Box<str>, Value>`
+/// - `dictionary-indexmap`: `IndexMap<Box<str>, Value>`
 #[cfg(feature = "dictionary-indexmap")]
-pub type Dictionary = indexmap::IndexMap<String, Value>;
+pub type Dictionary = indexmap::IndexMap<Box<str>, Value>;
 /// Dictionary storage used by [`Section::dictionary`][crate::Section::dictionary].
 ///
-/// In default builds this is `BTreeMap<String, Value>`.
+/// In default builds this is `BTreeMap<Box<str>, Value>`.
 #[cfg(not(feature = "dictionary-indexmap"))]
-pub type Dictionary = std::collections::BTreeMap<String, Value>;
+pub type Dictionary = std::collections::BTreeMap<Box<str>, Value>;
 
 /// Top-level section storage used by [`Ion`].
 ///
 /// The concrete map type depends on the `dictionary-indexmap` feature:
 ///
-/// - default: `BTreeMap<String, Section>`
-/// - `dictionary-indexmap`: `IndexMap<String, Section>`
+/// - default: `BTreeMap<Box<str>, Section>`
+/// - `dictionary-indexmap`: `IndexMap<Box<str>, Section>`
 #[cfg(feature = "dictionary-indexmap")]
-pub type Sections = indexmap::IndexMap<String, Section>;
+pub type Sections = indexmap::IndexMap<Box<str>, Section>;
 /// Top-level section storage used by [`Ion`].
 ///
-/// In default builds this is `BTreeMap<String, Section>`.
+/// In default builds this is `BTreeMap<Box<str>, Section>`.
 #[cfg(not(feature = "dictionary-indexmap"))]
-pub type Sections = std::collections::BTreeMap<String, Section>;
+pub type Sections = std::collections::BTreeMap<Box<str>, Section>;
 
 /// A single table row stored inside a [`Section`].
 pub type Row = Vec<Value>;

--- a/ion/src/parser.rs
+++ b/ion/src/parser.rs
@@ -6,13 +6,13 @@ use std::{error, fmt, str};
 #[derive(Debug, PartialEq)]
 pub enum Element {
     /// A section header like `[APP]`.
-    Section(String),
+    Section(Box<str>),
     /// A table row.
     Row(Vec<Value>),
     /// A dictionary entry like `key = value`.
-    Entry(String, Value),
+    Entry(Box<str>, Value),
     /// A comment line without the leading `#`.
-    Comment(String),
+    Comment(Box<str>),
 }
 
 /// Stateful parser for Ion text.
@@ -152,7 +152,7 @@ impl<'a> Parser<'a> {
         }
 
         Some(Element::Comment(
-            self.slice_to_including('\n').unwrap_or("").to_string(),
+            self.slice_to_including('\n').unwrap_or("").into(),
         ))
     }
 
@@ -166,7 +166,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn section_name(&mut self) -> String {
+    fn section_name(&mut self) -> Box<str> {
         self.eat('[');
         self.whitespace();
 
@@ -174,7 +174,8 @@ impl<'a> Parser<'a> {
             .by_ref()
             .map(|(_, c)| c)
             .take_while(|c| *c != ']')
-            .collect()
+            .collect::<String>()
+            .into()
     }
 
     fn entry(&mut self) -> Option<Element> {
@@ -191,9 +192,9 @@ impl<'a> Parser<'a> {
         None
     }
 
-    fn key_name(&mut self) -> Option<String> {
+    fn key_name(&mut self) -> Option<Box<str>> {
         self.slice_while(|ch| matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-'))
-            .map(str::to_owned)
+            .map(Into::into)
     }
 
     fn value(&mut self) -> Option<Value> {
@@ -421,7 +422,7 @@ impl<'a> Parser<'a> {
                 map.insert(name, section);
             }
             None if self.accepted_sections.is_none() => {
-                map.insert("root".to_string(), section);
+                map.insert("root".into(), section);
             }
             _ => (),
         }
@@ -828,7 +829,7 @@ mod tests {
     fn dictionary(entries: Vec<(&str, Value)>) -> Value {
         let mut dictionary = Dictionary::new();
         for (key, value) in entries {
-            dictionary.insert(key.to_owned(), value);
+            dictionary.insert(key.into(), value);
         }
         Value::Dictionary(dictionary)
     }
@@ -840,7 +841,7 @@ mod tests {
     fn section(entries: Vec<(&str, Value)>, rows: Vec<Vec<Value>>) -> Section {
         let mut section = Section::new();
         for (key, value) in entries {
-            section.dictionary.insert(key.to_owned(), value);
+            section.dictionary.insert(key.into(), value);
         }
         section.rows = rows;
         section
@@ -849,7 +850,7 @@ mod tests {
     fn sections(entries: Vec<(&str, Section)>) -> Sections {
         let mut sections = Sections::new();
         for (name, section) in entries {
-            sections.insert(name.to_owned(), section);
+            sections.insert(name.into(), section);
         }
         sections
     }
@@ -1043,15 +1044,15 @@ mod tests {
                 | this |
             "#,
             expected: vec![
-                Element::Section("dict".to_owned()),
-                Entry("first".to_owned(), string("first")),
-                Comment(" comment\n".to_owned()),
-                Entry("second".to_owned(), string("another")),
-                Entry("whitespace".to_owned(), string("  ")),
-                Entry("empty".to_owned(), string("")),
-                Entry("some_bool".to_owned(), Value::Boolean(true)),
+                Element::Section("dict".into()),
+                Entry("first".into(), string("first")),
+                Comment(" comment\n".into()),
+                Entry("second".into(), string("another")),
+                Entry("whitespace".into(), string("  ")),
+                Entry("empty".into(), string("")),
+                Entry("some_bool".into(), Value::Boolean(true)),
                 Entry(
-                    "ary".to_owned(),
+                    "ary".into(),
                     array(vec![
                         string("col1"),
                         Value::Integer(2),
@@ -1059,16 +1060,16 @@ mod tests {
                         Value::Boolean(false),
                     ]),
                 ),
-                Element::Section("table".to_owned()),
+                Element::Section("table".into()),
                 Row(row(&["abc", "def"])),
                 Row(row(&["---", "---"])),
                 Row(row(&["one", "two"])),
-                Comment(" comment\n".to_owned()),
+                Comment(" comment\n".into()),
                 Row(row(&["1", "2"])),
                 Row(row(&["2", "3"])),
-                Element::Section("three".to_owned()),
-                Entry("a".to_owned(), Value::Integer(1)),
-                Entry("B".to_owned(), Value::Integer(2)),
+                Element::Section("three".into()),
+                Entry("a".into(), Value::Integer(1)),
+                Entry("B".into(), Value::Integer(2)),
                 Row(row(&["this"])),
             ],
         });
@@ -1076,9 +1077,9 @@ mod tests {
         LazyLock::new(|| ParseIteratorTestCase {
             raw: "foo = \"bar\"\r\n# comment\r\nbaz = false\r\n",
             expected: vec![
-                Entry("foo".to_owned(), string("bar")),
-                Comment(" comment\r\n".to_owned()),
-                Entry("baz".to_owned(), Value::Boolean(false)),
+                Entry("foo".into(), string("bar")),
+                Comment(" comment\r\n".into()),
+                Entry("baz".into(), Value::Boolean(false)),
             ],
         });
 
@@ -1094,7 +1095,7 @@ mod tests {
 
     static COMMENT_PRESENT_CASE: LazyLock<CommentTestCase> = LazyLock::new(|| CommentTestCase {
         raw: "# comment\n",
-        expected: Some(Comment(" comment\n".to_owned())),
+        expected: Some(Comment(" comment\n".into())),
         next: None,
     });
     const COMMENT_ABSENT_CASE: CommentTestCase = CommentTestCase {
@@ -1530,7 +1531,10 @@ mod tests {
     #[test_case(&SECTION_ORDERING_CASE; "section ordering depends on backend")]
     fn section_ordering(case: &SectionOrderingTestCase) {
         let sections = Parser::new(case.raw).read().unwrap();
-        let actual = sections.keys().map(String::as_str).collect::<Vec<_>>();
+        let actual = sections
+            .keys()
+            .map(std::convert::AsRef::as_ref)
+            .collect::<Vec<_>>();
         assert_eq!(case.expected, actual.as_slice());
     }
 
@@ -1581,10 +1585,10 @@ mod tests {
             "#,
             accepted_sections: &["ACCEPTED"],
             expected_prefix: vec![
-                Element::Section("ACCEPTED".to_owned()),
-                Entry("key".to_owned(), string("value")),
+                Element::Section("ACCEPTED".into()),
+                Entry("key".into(), string("value")),
             ],
-            expected_after_none: Some(Entry("other".to_owned(), string("ignored"))),
+            expected_after_none: Some(Entry("other".into(), string("ignored"))),
         });
 
     #[test_case(&*FILTER_ITERATION_EXHAUSTS_ACCEPTED_SECTIONS; "accepted sections exhausted")]


### PR DESCRIPTION
- store Dictionary/Sections keys as Box<str>
- switch parser Element string payloads to Box<str>
- return &str keys from Ion::iter and Ion::get_key_value
- update changelog/readmes and bump workspace ion version

BREAKING CHANGE: map key types changed from String to Box<str>; Ion key-returning APIs now use &str.